### PR TITLE
Enable havling hardfork on mainnet

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -156,7 +156,7 @@ var (
 		GrayGlacierBlock:    big.NewInt(0),
 		ShanghaiTime:        newUint64(0),
 		PizzaTime:           newUint64(0),
-		// HalvingTime:           newUint64(0),
+		HalvingTime:         newUint64(1717063200), // 2024-05-30 10:00:00 UTC
 		Merlion: &MerlionConfig{
 			Period: 3,
 			Epoch:  200,

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1        // Major version component of the current release
 	VersionMinor = 1        // Minor version component of the current release
-	VersionPatch = 1        // Patch version component of the current release
+	VersionPatch = 2        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
Enable havling hardfork on mainnet.

The target Halving hard fork time on mainnet will be 2024-05-30 10:00:00 AM UTC .
Every mainnet node needs to upgrade to this version before the hard fork time.