### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/docs/postmortems/2021-08-22-split-postmortem.md
+++ b/docs/postmortems/2021-08-22-split-postmortem.md
@@ -128,8 +128,8 @@ Action point: enable push-based alerts to be sent from the forkmon, to speed up 
 
 ## Links
 
-- [1] https://twitter.com/go_ethereum/status/1428051458763763721
-- [2] https://twitter.com/mhswende/status/1431259601530458112
+- [1] https://x.com/go_ethereum/status/1428051458763763721
+- [2] https://x.com/mhswende/status/1431259601530458112
 
 
 ## Appendix
@@ -147,7 +147,7 @@ recommend downstream/dependent projects to be ready to take actions to
 upgrade to the latest go-ethereum codebase. More information about the
 issue will be disclosed at a later date.
 
-https://twitter.com/go_ethereum/status/1428051458763763721
+https://x.com/go_ethereum/status/1428051458763763721
 
 ```
 ### Patch


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com/) with the updated x.com format (https://x.com/) to align with the platform's rebranding.