### PR TITLE
update actions/checkout from v2 to v4 #145

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
           go-version: 1.21.4
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Lint Go Code
         run: |
@@ -31,7 +31,7 @@ jobs:
           go-version: 1.21.4
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run Unit tests.
         run:  |
@@ -48,7 +48,7 @@ jobs:
           go-version: 1.21.4
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build
         run:  |


### PR DESCRIPTION
Changes:

Updates all instances of actions/checkout@v2 to actions/checkout@v4
This is the last file requiring this update, all other files have been updated
Reference:
Latest version confirmation: https://github.com/actions/checkout/releases/tag/v4.2.2

This update ensures we're using the most recent stable version of the GitHub checkout action across our CI/CD pipelines.