### PR TITLE
fix(typos): correct minor typos in comments across core/rawdb, state, and snapshot

### DIFF
--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -228,7 +228,7 @@ func TestBadBlockStorage(t *testing.T) {
 		t.Fatalf("Failed to load all bad blocks")
 	}
 
-	// Write a bunch of bad blocks, all the blocks are should sorted
+	// Write a bunch of bad blocks, all the blocks should sorted
 	// in reverse order. The extra blocks should be truncated.
 	for _, n := range rand.Perm(100) {
 		block := types.NewBlockWithHeader(&types.Header{

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -894,7 +894,7 @@ func getChunk(size int, b int) []byte {
 }
 
 // TODO (?)
-// - test that if we remove several head-files, aswell as data last data-file,
+// - test that if we remove several head-files, as well as data last data-file,
 //   the index is truncated accordingly
 // Right now, the freezer would fail on these conditions:
 // 1. have data files d0, d1, d2, d3

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -275,7 +275,7 @@ func TestFreezerReadonlyValidate(t *testing.T) {
 	}
 	require.NoError(t, f.Close())
 
-	// Re-openening as readonly should fail when validating
+	//Re-opening as readonly should fail when validating
 	// table lengths.
 	_, err = NewFreezer(dir, "", true, 2049, tables)
 	if err == nil {

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -121,7 +121,7 @@ func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, sta
 	// the trie nodes(and codes) belong to the active state will be filtered
 	// out. A very small part of stale tries will also be filtered because of
 	// the false-positive rate of bloom filter. But the assumption is held here
-	// that the false-positive is low enough(~0.05%). The probablity of the
+	// that the false-positive is low enough(~0.05%). The probability of the
 	// dangling node is the state root is super low. So the dangling nodes in
 	// theory will never ever be visited again.
 	var (

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -43,7 +43,7 @@ var (
 	aggregatorMemoryLimit = uint64(4 * 1024 * 1024)
 
 	// aggregatorItemLimit is an approximate number of items that will end up
-	// in the agregator layer before it's flushed out to disk. A plain account
+	// in the aggregator layer before it's flushed out to disk. A plain account
 	// weighs around 14B (+hash), a storage slot 32B (+hash), a deleted slot
 	// 0B (+hash). Slots are mostly set/unset in lockstep, so that average at
 	// 16B (+hash). All in all, the average entry seems to be 15+32=47B. Use a


### PR DESCRIPTION
- Fixed comment typo: "are should sorted" → "should be sorted" in accessors_chain_test.go

- Changed "aswell" → "as well" in freezer_table_test.go

- Corrected "Re-openening" → "Re-opening" in freezer_test.go

- Fixed "probablity" → "probability" in pruner.go

- Corrected "agregator" → "aggregator" in difflayer.go