### PR TITLE
fix: update Go download URLs from dl.google.com to go.dev

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -764,7 +764,7 @@ func downloadGoBootstrapSources(cachedir string) string {
 		log.Fatal(err)
 	}
 	file := fmt.Sprintf("go%s.src.tar.gz", gobootVersion)
-	url := "https://dl.google.com/go/" + file
+	url := "https://go.dev/dl/" + file
 	dst := filepath.Join(cachedir, file)
 	if err := csdb.DownloadFile(url, dst); err != nil {
 		log.Fatal(err)
@@ -780,7 +780,7 @@ func downloadGoSources(cachedir string) string {
 		log.Fatal(err)
 	}
 	file := fmt.Sprintf("go%s.src.tar.gz", dlgoVersion)
-	url := "https://dl.google.com/go/" + file
+	url := "https://go.dev/dl/" + file
 	dst := filepath.Join(cachedir, file)
 	if err := csdb.DownloadFile(url, dst); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Replace deprecated dl.google.com/go/ URLs with official go.dev/dl/ URLsfor downloading Go source tarballs in CI build scripts.

This ensures reliable access to Go downloads using the current official Go distribution endpoints.