### PR TITLE
refactor: rename variable to avoid shadowing built-in int type

### DIFF
--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -54,11 +54,11 @@ func (i *HexOrDecimal64) UnmarshalJSON(input []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *HexOrDecimal64) UnmarshalText(input []byte) error {
-	int, ok := ParseUint64(string(input))
+	val, ok := ParseUint64(string(input))
 	if !ok {
 		return fmt.Errorf("invalid hex or decimal integer %q", input)
 	}
-	*i = HexOrDecimal64(int)
+	*i = HexOrDecimal64(val)
 	return nil
 }
 


### PR DESCRIPTION
Replace variable name 'int' with 'val' in HexOrDecimal64.UnmarshalText to follow Go naming conventions and avoid shadowing the built-in int type