### PR TITLE
docs: fix typos in comments for improved clarity

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -83,7 +83,7 @@ const (
 	minTrienodeHealThrottle = 1
 
 	// maxTrienodeHealThrottle is the maximum divisor for throttling trie node
-	// heal requests to avoid overloading the local node and exessively expanding
+	// heal requests to avoid overloading the local node and excessively expanding
 	// the state trie bedth wise.
 	maxTrienodeHealThrottle = maxTrieRequestCount
 

--- a/internal/flags/helpers.go
+++ b/internal/flags/helpers.go
@@ -115,7 +115,7 @@ func doMigrateFlags(ctx *cli.Context) {
 		for _, parent := range ctx.Lineage()[1:] {
 			if parent.IsSet(name) {
 				// When iterating across the lineage, we will be served both
-				// the 'canon' and alias formats of all commmands. In most cases,
+				// the 'canon' and alias formats of all commands. In most cases,
 				// it's fine to set it in the ctx multiple times (one for each
 				// name), however, the Slice-flags are not fine.
 				// The slice-flags accumulate, so if we set it once as

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -891,7 +891,7 @@ func (w *worker) commitTransactions(env *environment, txs transactionsByPriceAnd
 
 // generateParams wraps various of settings for generating sealing task.
 type generateParams struct {
-	timestamp   uint64            // The timstamp for sealing task
+	timestamp   uint64            // The timestamp for sealing task
 	forceTime   bool              // Flag whether the given timestamp is immutable or not
 	parentHash  common.Hash       // Parent block hash, empty means the latest chain head
 	coinbase    common.Address    // The fee recipient address for including transaction


### PR DESCRIPTION

- **Fixed "exessively" → "excessively"** in `eth/protocols/snap/sync.go`
- **Fixed "commmands" → "commands"** in `internal/flags/helpers.go`  
- **Fixed "timstamp" → "timestamp"** in `miner/worker.go`

